### PR TITLE
fix: include TypeScript declaration file in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "national-id"
   ],
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "type": "module",
   "types": "./index.d.ts",


### PR DESCRIPTION
Fixes #49

The package already had a type definition file (index.d.ts) and the package.json correctly referenced it, but the file was not being published to npm because it wasn't included in the "files" array.

This change adds index.d.ts to the files array so that TypeScript users will get proper type definitions when installing the package from npm.